### PR TITLE
added missing `shx` before rm command for angular project

### DIFF
--- a/packages/core/angular/package.json
+++ b/packages/core/angular/package.json
@@ -13,7 +13,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf lib/*",
+        "clean": "shx rm -rf lib/*",
         "build": "yarn clean && ng build angular --configuration=production"
     },
     "peerDependencies": {


### PR DESCRIPTION
Building angular package from source on windows fails since `rm` is missing command. Other packages use `shx rm...` so I believe this should be the case here as well. 