### PR TITLE
Bump @blocto/sdk version so that it doesn't break with Next.js

### DIFF
--- a/packages/wallets/blocto/package.json
+++ b/packages/wallets/blocto/package.json
@@ -30,6 +30,6 @@
         "@solana/web3.js": "^1.20.0"
     },
     "dependencies": {
-        "@blocto/sdk": "^0.2.11"
+        "@blocto/sdk": "^0.2.16"
     }
 }


### PR DESCRIPTION
There was a patch merged into the blocto-sdk main branch a week or two ago that fixes an issue where it would break when using with Next.js. However, this repo was still using a previous version and so anyone trying to use it would get the same Next.js error. This PR should resolve that issue.