### PR TITLE
update openlogin deps to behave well with es modules

### DIFF
--- a/packages/wallets/torus/package.json
+++ b/packages/wallets/torus/package.json
@@ -26,8 +26,8 @@
         "@solana/web3.js": "^1.20.0"
     },
     "dependencies": {
-        "@toruslabs/openlogin": "^0.10.2",
-        "@toruslabs/openlogin-ed25519": "^0.10.2",
+        "@toruslabs/openlogin": "^1.0.0",
+        "@toruslabs/openlogin-ed25519": "^1.0.0",
         "@types/keccak": "^3.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
Openlogin v1 exposes es modules under "module" key in package.json.

This should be picked up by the bundlers and behave well with the general scope of this package.
Refs #133 