### PR TITLE
chore: constrain the `connection` input of `sendTransaction` to the minimum interface actually required

### DIFF
--- a/packages/core/base/src/signer.ts
+++ b/packages/core/base/src/signer.ts
@@ -1,7 +1,8 @@
 import type { SolanaSignInInput, SolanaSignInOutput } from '@solana/wallet-standard-features';
-import type { Connection, TransactionSignature } from '@solana/web3.js';
+import type { TransactionSignature } from '@solana/web3.js';
 import {
     BaseWalletAdapter,
+    type ConnectionContext,
     type SendTransactionOptions,
     type WalletAdapter,
     type WalletAdapterProps,
@@ -26,7 +27,7 @@ export abstract class BaseSignerWalletAdapter<Name extends string = string>
 {
     async sendTransaction(
         transaction: TransactionOrVersionedTransaction<this['supportedTransactionVersions']>,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         let emit = true;
@@ -47,7 +48,7 @@ export abstract class BaseSignerWalletAdapter<Name extends string = string>
 
                     const rawTransaction = transaction.serialize();
 
-                    return await connection.sendRawTransaction(rawTransaction, options);
+                    return await connectionContext.sendRawTransaction(rawTransaction, options);
                 } catch (error: any) {
                     // If the error was thrown by `signTransaction`, rethrow it and don't emit a duplicate event
                     if (error instanceof WalletSignTransactionError) {
@@ -60,7 +61,7 @@ export abstract class BaseSignerWalletAdapter<Name extends string = string>
                 try {
                     const { signers, ...sendOptions } = options;
 
-                    transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                    transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                     signers?.length && transaction.partialSign(...signers);
 
@@ -68,7 +69,7 @@ export abstract class BaseSignerWalletAdapter<Name extends string = string>
 
                     const rawTransaction = transaction.serialize();
 
-                    return await connection.sendRawTransaction(rawTransaction, sendOptions);
+                    return await connectionContext.sendRawTransaction(rawTransaction, sendOptions);
                 } catch (error: any) {
                     // If the error was thrown by `signTransaction`, rethrow it and don't emit a duplicate event
                     if (error instanceof WalletSignTransactionError) {

--- a/packages/wallets/alpha/src/adapter.ts
+++ b/packages/wallets/alpha/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface AlphaWalletEvents {
@@ -158,7 +158,7 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -168,11 +168,11 @@ export class AlphaWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/avana/src/adapter.ts
+++ b/packages/wallets/avana/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface AvanaWalletEvents {
@@ -160,7 +160,7 @@ export class AvanaWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -170,11 +170,11 @@ export class AvanaWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/coinbase/src/adapter.ts
+++ b/packages/wallets/coinbase/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     isVersionedTransaction,
@@ -16,7 +16,6 @@ import {
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
 import type {
-    Connection,
     SendOptions,
     Transaction,
     VersionedTransaction,
@@ -157,7 +156,7 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction<T extends Transaction | VersionedTransaction>(
         transaction: T,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -170,11 +169,11 @@ export class CoinbaseWalletAdapter extends BaseMessageSignerWalletAdapter {
                 if (isVersionedTransaction(transaction)) {
                     signers?.length && transaction.sign(signers);
                 } else {
-                    transaction = (await this.prepareTransaction(transaction, connection, sendOptions)) as T;
+                    transaction = (await this.prepareTransaction(transaction, connectionContext, sendOptions)) as T;
                     signers?.length && (transaction as Transaction).partialSign(...signers);
                 }
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/nufi/src/adapter.ts
+++ b/packages/wallets/nufi/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     isVersionedTransaction,
@@ -16,13 +16,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type {
-    Connection,
-    Transaction,
-    TransactionSignature,
-    TransactionVersion,
-    VersionedTransaction,
-} from '@solana/web3.js';
+import type { Transaction, TransactionSignature, TransactionVersion, VersionedTransaction } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface NufiWalletEvents {
@@ -161,7 +155,7 @@ export class NufiWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction<T extends Transaction | VersionedTransaction>(
         transaction: T,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -174,11 +168,11 @@ export class NufiWalletAdapter extends BaseMessageSignerWalletAdapter {
                 if (isVersionedTransaction(transaction)) {
                     signers?.length && transaction.sign(signers);
                 } else {
-                    transaction = (await this.prepareTransaction(transaction, connection, sendOptions)) as T;
+                    transaction = (await this.prepareTransaction(transaction, connectionContext, sendOptions)) as T;
                     signers?.length && (transaction as Transaction).partialSign(...signers);
                 }
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
                 const { signature } = await wallet.signAndSendTransaction(transaction);
                 return signature;
             } catch (error: any) {

--- a/packages/wallets/phantom/src/adapter.ts
+++ b/packages/wallets/phantom/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     isIosAndRedirectable,
@@ -18,7 +18,6 @@ import {
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
 import type {
-    Connection,
     SendOptions,
     Transaction,
     TransactionSignature,
@@ -193,7 +192,7 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction<T extends Transaction | VersionedTransaction>(
         transaction: T,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -206,11 +205,11 @@ export class PhantomWalletAdapter extends BaseMessageSignerWalletAdapter {
                 if (isVersionedTransaction(transaction)) {
                     signers?.length && transaction.sign(signers);
                 } else {
-                    transaction = (await this.prepareTransaction(transaction, connection, sendOptions)) as T;
+                    transaction = (await this.prepareTransaction(transaction, connectionContext, sendOptions)) as T;
                     signers?.length && (transaction as Transaction).partialSign(...signers);
                 }
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/saifu/src/adapter.ts
+++ b/packages/wallets/saifu/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface SaifuWalletEvents {
@@ -158,7 +158,7 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -169,11 +169,11 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
                 try {
                     const { signers, ...sendOptions } = options;
 
-                    transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                    transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                     signers?.length && transaction.partialSign(...signers);
 
-                    sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                    sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                     const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                     return signature;
@@ -187,7 +187,7 @@ export class SaifuWalletAdapter extends BaseMessageSignerWalletAdapter {
             throw error;
         }
 
-        return await super.sendTransaction(transaction, connection, options);
+        return await super.sendTransaction(transaction, connectionContext, options);
     }
 
     async signTransaction<T extends Transaction>(transaction: T): Promise<T> {

--- a/packages/wallets/sky/src/adapter.ts
+++ b/packages/wallets/sky/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface SkyWalletEvents {
@@ -155,7 +155,7 @@ export class SkyWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -165,11 +165,11 @@ export class SkyWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/solflare/src/adapter.ts
+++ b/packages/wallets/solflare/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { WalletAdapterNetwork, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, WalletAdapterNetwork, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     WalletConfigError,
@@ -20,7 +20,7 @@ import {
     type SendTransactionOptions,
 } from '@solana/wallet-adapter-base';
 import type { Transaction, TransactionVersion, VersionedTransaction } from '@solana/web3.js';
-import { PublicKey, type Connection, type TransactionSignature } from '@solana/web3.js';
+import { PublicKey, type TransactionSignature } from '@solana/web3.js';
 import type { default as Solflare } from '@solflare-wallet/sdk';
 import { detectAndRegisterSolflareMetaMaskWallet } from './metamask/detect.js';
 
@@ -183,7 +183,7 @@ export class SolflareWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction<T extends Transaction | VersionedTransaction>(
         transaction: T,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -196,11 +196,11 @@ export class SolflareWalletAdapter extends BaseMessageSignerWalletAdapter {
                 if (isVersionedTransaction(transaction)) {
                     signers?.length && transaction.sign(signers);
                 } else {
-                    transaction = (await this.prepareTransaction(transaction, connection, sendOptions)) as T;
+                    transaction = (await this.prepareTransaction(transaction, connectionContext, sendOptions)) as T;
                     signers?.length && (transaction as Transaction).partialSign(...signers);
                 }
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 return await wallet.signAndSendTransaction(transaction, sendOptions);
             } catch (error: any) {

--- a/packages/wallets/tokenary/src/adapter.ts
+++ b/packages/wallets/tokenary/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface TokenaryWalletEvents {
@@ -156,7 +156,7 @@ export class TokenaryWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -166,11 +166,11 @@ export class TokenaryWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/torus/src/adapter.ts
+++ b/packages/wallets/torus/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     WalletAccountError,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 import type { default as Torus, TorusParams } from '@toruslabs/solana-embed';
 
@@ -147,7 +147,7 @@ export class TorusWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -157,11 +157,11 @@ export class TorusWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;

--- a/packages/wallets/trust/src/adapter.ts
+++ b/packages/wallets/trust/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
+import type { ConnectionContext, EventEmitter, SendTransactionOptions, WalletName } from '@solana/wallet-adapter-base';
 import {
     BaseMessageSignerWalletAdapter,
     scopePollingDetectionStrategy,
@@ -15,7 +15,7 @@ import {
     WalletSignMessageError,
     WalletSignTransactionError,
 } from '@solana/wallet-adapter-base';
-import type { Connection, SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
+import type { SendOptions, Transaction, TransactionSignature } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
 interface TrustWalletEvents {
@@ -160,7 +160,7 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
 
     async sendTransaction(
         transaction: Transaction,
-        connection: Connection,
+        connectionContext: ConnectionContext,
         options: SendTransactionOptions = {}
     ): Promise<TransactionSignature> {
         try {
@@ -170,11 +170,11 @@ export class TrustWalletAdapter extends BaseMessageSignerWalletAdapter {
             try {
                 const { signers, ...sendOptions } = options;
 
-                transaction = await this.prepareTransaction(transaction, connection, sendOptions);
+                transaction = await this.prepareTransaction(transaction, connectionContext, sendOptions);
 
                 signers?.length && transaction.partialSign(...signers);
 
-                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connection.commitment;
+                sendOptions.preflightCommitment = sendOptions.preflightCommitment || connectionContext.commitment;
 
                 const { signature } = await wallet.signAndSendTransaction(transaction, sendOptions);
                 return signature;


### PR DESCRIPTION
The `sendTransaction()` method takes in a `Connection` from `@solana/web3.js` but actually requires very little of it; just `commitment`, `sendRawTransaction()`, and `getLatestBlockhash()`.

In this PR we constrain the interface to exactly that and no more. This will make it easier to supply _non_ `@solana/web3.js` implementations at that callsite, so long as they can fulfil the same contract.