### PR TITLE
Add a pnpm override for ngraveio/bc-ur

### DIFF
--- a/.changeset/brown-camels-peel.md
+++ b/.changeset/brown-camels-peel.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-keystone': patch
+---
+
+Add a pnpm override for ngraveio/bc-ur

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@solana/wallet-adapter-base": "workspace:^",
         "@types/web": "npm:typescript@~4.7.4",
-        "eslint": "8.22.0"
+        "eslint": "8.22.0",
+        "@ngraveio/bc-ur": "1.1.6"
     },
     "resolutions": {
         "@ledgerhq/devices": "6.27.1",


### PR DESCRIPTION
A new patch version of `@ngraveio/bc-ur` was released, it has some issue and can't be used (https://github.com/ngraveio/bc-ur/issues/21#issuecomment-1973717698), the keystone wallet adapter has a nested dependency on it and is picking up the new version, and this breaks `wallet-adapter-wallets`

This PR uses a pnpm override to pin `@ngraveio/bc-ur` to 1.16 for now. The broken versions released yesterday are 1.1.8 and 1.1.9

Workaround for #909  until it's fixed upstream