### PR TITLE
docs: using `import` instead `require`

### DIFF
--- a/APP.md
+++ b/APP.md
@@ -37,7 +37,7 @@ import {
 import { clusterApiUrl } from '@solana/web3.js';
 
 // Default styles that can be overridden by your app
-require('@solana/wallet-adapter-react-ui/styles.css');
+import('@solana/wallet-adapter-react-ui/styles.css');
 
 export const Wallet: FC = () => {
     // The network can be set to 'devnet', 'testnet', or 'mainnet-beta'.

--- a/APP.md
+++ b/APP.md
@@ -37,7 +37,7 @@ import {
 import { clusterApiUrl } from '@solana/web3.js';
 
 // Default styles that can be overridden by your app
-import('@solana/wallet-adapter-react-ui/styles.css');
+import '@solana/wallet-adapter-react-ui/styles.css';
 
 export const Wallet: FC = () => {
     // The network can be set to 'devnet', 'testnet', or 'mainnet-beta'.


### PR DESCRIPTION
in modern React tooling import statement is more preferable