### PR TITLE
fix: fix Trezor adapter on Firefox browsers

### DIFF
--- a/.changeset/silly-rats-accept.md
+++ b/.changeset/silly-rats-accept.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-adapter-trezor': patch
+---
+
+Fix Trezor adapter on Firefox browsers

--- a/packages/wallets/trezor/src/adapter.ts
+++ b/packages/wallets/trezor/src/adapter.ts
@@ -45,10 +45,7 @@ export class TrezorWalletAdapter extends BaseSignerWalletAdapter {
     private _connecting: boolean;
     private _publicKey: PublicKey | null;
     private _readyState: WalletReadyState =
-        typeof window === 'undefined' ||
-        typeof document === 'undefined' ||
-        typeof navigator === 'undefined' ||
-        !navigator.hid
+        typeof window === 'undefined' || typeof document === 'undefined'
             ? WalletReadyState.Unsupported
             : WalletReadyState.Loadable;
 


### PR DESCRIPTION
We received a bug report that the Trezor wallet adapter was not available on Firefox. This PR fixes the Trezor adapter on Firefox (and Safari as well although Safari is not supported by Trezor Connect anyways).

Sorry, I didn't notice the `!navigator.hid` check before which I copied over from Ledger. It is not needed for the Trezor as Trezor doesn't use HID.

**How to reproduce**

Try the currently released Trezor adapter on Firefox browsers. See e.g. [here](https://jup.ag/) that Trezor is not available on Firefox while it is available on Chrome.

**How to test**

Try the updated Trezor adapter e.g. in the example in this repo. Trezor should be available on both Firefox and Chrome.