### PR TITLE
docs: add Ant Design Web3 to the document

### DIFF
--- a/APP.md
+++ b/APP.md
@@ -6,7 +6,7 @@ See the [packages](https://github.com/anza-xyz/wallet-adapter/blob/master/PACKAG
 
 ## Quick Setup (using React UI)
 
-There are also [material-ui](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/material-ui) and [ant-design](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/ant-design) or [Ant Design Web3](https://web3.ant.design/components/solana) packages if you use those UI component frameworks.
+There are also [material-ui](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/material-ui) and [ant-design](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/ant-design) packages if you use those UI component frameworks.
 
 ### Install
 

--- a/APP.md
+++ b/APP.md
@@ -6,7 +6,7 @@ See the [packages](https://github.com/anza-xyz/wallet-adapter/blob/master/PACKAG
 
 ## Quick Setup (using React UI)
 
-There are also [material-ui](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/material-ui) and [ant-design](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/ant-design) packages if you use those UI component frameworks.
+There are also [material-ui](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/material-ui) and [ant-design](https://github.com/anza-xyz/wallet-adapter/tree/master/packages/ui/ant-design) or [Ant Design Web3](https://web3.ant.design/components/solana) packages if you use those UI component frameworks.
 
 ### Install
 

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -28,7 +28,9 @@ These packages provide components for common UI frameworks.
 | [react-ui](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/react-ui)                | Components for React (no UI framework, just CSS)                   | [`@solana/wallet-adapter-react-ui`](https://npmjs.com/package/@solana/wallet-adapter-react-ui)             |
 | [material-ui](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/material-ui)          | Components for [Material UI](https://material-ui.com) with React   | [`@solana/wallet-adapter-material-ui`](https://npmjs.com/package/@solana/wallet-adapter-material-ui)       |
 | [ant-design](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/ant-design)            | Components for [Ant Design](https://ant.design) with React         | [`@solana/wallet-adapter-ant-design`](https://npmjs.com/package/@solana/wallet-adapter-ant-design)         |
+| [Ant Design Web3](https://web3.ant.design/components/solana)            | Web3 react components made by [Ant Design](https://ant.design) team        | [`@ant-design/web3-solana`](https://www.npmjs.com/package/@ant-design/web3-solana)         |
 | [angular-material-ui](https://github.com/heavy-duty/platform/tree/master/libs/wallet-adapter/ui/material) | Components for [Angular Material UI](https://material.angular.io/) | [`@heavy-duty/wallet-adapter-material`](https://www.npmjs.com/package/@heavy-duty/wallet-adapter-material) |
+
 
 ### Wallets
 These packages provide adapters for each wallet.

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -31,7 +31,6 @@ These packages provide components for common UI frameworks.
 | [ant-design](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/ant-design)            | Components for [Ant Design](https://ant.design) with React         | [`@solana/wallet-adapter-ant-design`](https://npmjs.com/package/@solana/wallet-adapter-ant-design)         |
 | [angular-material-ui](https://github.com/heavy-duty/platform/tree/master/libs/wallet-adapter/ui/material) | Components for [Angular Material UI](https://material.angular.io/) | [`@heavy-duty/wallet-adapter-material`](https://www.npmjs.com/package/@heavy-duty/wallet-adapter-material) |
 
-
 ### Wallets
 These packages provide adapters for each wallet.
 You can use the [wallets](https://github.com/solana-labs/wallet-adapter/tree/master/packages/wallets/wallets) package, or add the individual wallet packages you want.

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -19,6 +19,7 @@ Several core packages are maintained by the community to support additional fron
 - [Angular](https://github.com/heavy-duty/platform/tree/master/libs/wallet-adapter)
 - [Svelte](https://github.com/svelte-on-solana/wallet-adapter)
 - [TypeScript](https://github.com/ronanyeah/solana-connect)
+- [Ant Design Web3](https://web3.ant.design/components/solana)
 
 ### UI Components
 These packages provide components for common UI frameworks.
@@ -28,7 +29,6 @@ These packages provide components for common UI frameworks.
 | [react-ui](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/react-ui)                | Components for React (no UI framework, just CSS)                   | [`@solana/wallet-adapter-react-ui`](https://npmjs.com/package/@solana/wallet-adapter-react-ui)             |
 | [material-ui](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/material-ui)          | Components for [Material UI](https://material-ui.com) with React   | [`@solana/wallet-adapter-material-ui`](https://npmjs.com/package/@solana/wallet-adapter-material-ui)       |
 | [ant-design](https://github.com/solana-labs/wallet-adapter/tree/master/packages/ui/ant-design)            | Components for [Ant Design](https://ant.design) with React         | [`@solana/wallet-adapter-ant-design`](https://npmjs.com/package/@solana/wallet-adapter-ant-design)         |
-| [Ant Design Web3](https://web3.ant.design/components/solana)            | Web3 react components made by [Ant Design](https://ant.design) team        | [`@ant-design/web3-solana`](https://www.npmjs.com/package/@ant-design/web3-solana)         |
 | [angular-material-ui](https://github.com/heavy-duty/platform/tree/master/libs/wallet-adapter/ui/material) | Components for [Angular Material UI](https://material.angular.io/) | [`@heavy-duty/wallet-adapter-material`](https://www.npmjs.com/package/@heavy-duty/wallet-adapter-material) |
 
 


### PR DESCRIPTION
Ant Design Web3 now supports Solana based on `@solana/wallet-adapter-react`. We hope to incorporate this into the documentation to encourage more developers to try it out.