### PR TITLE
XDEFI Wallet Adapter: Update XDEFIWalletName

### DIFF
--- a/packages/wallets/xdefi/src/adapter.ts
+++ b/packages/wallets/xdefi/src/adapter.ts
@@ -46,7 +46,7 @@ declare const window: XDEFIWalletWindow;
 
 export interface XDEFIWalletAdapterConfig {}
 
-export const XDEFIWalletName = 'XDEFI' as WalletName<'XDEFI'>;
+export const XDEFIWalletName = 'XDEFI Wallet' as WalletName<'XDEFI Wallet'>;
 
 export class XDEFIWalletAdapter extends BaseMessageSignerWalletAdapter {
     name = XDEFIWalletName;


### PR DESCRIPTION
Match name in adapter to XDEFI Wallet extension name. This fixes issue when XDEFI wallet listed twice in connect wallet modal
<img width="582" alt="image" src="https://github.com/anza-xyz/wallet-adapter/assets/98474638/04afac9a-b305-42f9-aed0-8cc89823821c">
