### PR TITLE
fix: TransportRaceCondition is not found becasue it is renamed to TransportPendingOperation

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     },
     "overrides": {
         "@ledgerhq/devices": "6.27.1",
+        "@ledgerhq/errors": "6.16.3",
         "@ledgerhq/hw-transport": "6.27.1",
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@solana/wallet-adapter-base": "workspace:^",
@@ -58,6 +59,7 @@
     },
     "resolutions": {
         "@ledgerhq/devices": "6.27.1",
+        "@ledgerhq/errors": "6.16.3",
         "@ledgerhq/hw-transport": "6.27.1",
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@solana/wallet-adapter-base": "workspace:^",


### PR DESCRIPTION
https://github.com/LedgerHQ/ledger-live/commit/931d511f5c5da86ddee53c69775515da019b6241

 <details>
   <summary>Expaned view</summary>


```
npm why @ledgerhq/errors
@ledgerhq/errors@6.16.4
node_modules/@ledgerhq/errors
  @ledgerhq/errors@"^6.10.0" from @ledgerhq/devices@6.27.1
  node_modules/@ledgerhq/devices
    @ledgerhq/devices@"^6.27.1" from @ledgerhq/hw-transport@6.27.1
    node_modules/@ledgerhq/hw-transport
      @ledgerhq/hw-transport@"^6.27.1" from @ledgerhq/hw-transport-webhid@6.27.1
      node_modules/@ledgerhq/hw-transport-webhid
        @ledgerhq/hw-transport-webhid@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
        node_modules/@solana/wallet-adapter-ledger
          @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
          node_modules/@solana/wallet-adapter-wallets
            @solana/wallet-adapter-wallets@"^0.19.32" from the root project
      @ledgerhq/hw-transport@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
      node_modules/@solana/wallet-adapter-ledger
        @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
        node_modules/@solana/wallet-adapter-wallets
          @solana/wallet-adapter-wallets@"^0.19.32" from the root project
    @ledgerhq/devices@"^6.27.1" from @ledgerhq/hw-transport-webhid@6.27.1
    node_modules/@ledgerhq/hw-transport-webhid
      @ledgerhq/hw-transport-webhid@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
      node_modules/@solana/wallet-adapter-ledger
        @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
        node_modules/@solana/wallet-adapter-wallets
          @solana/wallet-adapter-wallets@"^0.19.32" from the root project
    @ledgerhq/devices@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
    node_modules/@solana/wallet-adapter-ledger
      @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
      node_modules/@solana/wallet-adapter-wallets
        @solana/wallet-adapter-wallets@"^0.19.32" from the root project
  @ledgerhq/errors@"^6.10.0" from @ledgerhq/hw-transport@6.27.1
  node_modules/@ledgerhq/hw-transport
    @ledgerhq/hw-transport@"^6.27.1" from @ledgerhq/hw-transport-webhid@6.27.1
    node_modules/@ledgerhq/hw-transport-webhid
      @ledgerhq/hw-transport-webhid@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
      node_modules/@solana/wallet-adapter-ledger
        @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
        node_modules/@solana/wallet-adapter-wallets
          @solana/wallet-adapter-wallets@"^0.19.32" from the root project
    @ledgerhq/hw-transport@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
    node_modules/@solana/wallet-adapter-ledger
      @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
      node_modules/@solana/wallet-adapter-wallets
        @solana/wallet-adapter-wallets@"^0.19.32" from the root project
  @ledgerhq/errors@"^6.10.0" from @ledgerhq/hw-transport-webhid@6.27.1
  node_modules/@ledgerhq/hw-transport-webhid
    @ledgerhq/hw-transport-webhid@"6.27.1" from @solana/wallet-adapter-ledger@0.9.25
    node_modules/@solana/wallet-adapter-ledger
      @solana/wallet-adapter-ledger@"^0.9.25" from @solana/wallet-adapter-wallets@0.19.32
      node_modules/@solana/wallet-adapter-wallets
        @solana/wallet-adapter-wallets@"^0.19.32" from the root project
```

</details>

