### PR TITLE
Allow Disconnect of MWA 

### DIFF
--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -159,8 +159,7 @@ export function WalletProvider({
     const handleConnectError = useCallback(() => {
         if (
             adapter &&
-            adapter.name !== SolanaMobileWalletAdapterWalletName &&
-            adaptersWithStandardAdapters.length === 0
+            (adapter.name !== SolanaMobileWalletAdapterWalletName || adaptersWithStandardAdapters.length !== 0)
         ) {
             // If any error happens while connecting, unset the adapter.
             changeWallet(null);

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -76,7 +76,12 @@ export function WalletProvider({
         }
         return [mobileWalletAdapter, ...adaptersWithStandardAdapters];
     }, [adaptersWithStandardAdapters, mobileWalletAdapter]);
-    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(localStorageKey, null);
+    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(
+        localStorageKey,
+        adaptersWithStandardAdapters.length === 0 && getIsMobile(adaptersWithStandardAdapters)
+            ? SolanaMobileWalletAdapterWalletName
+            : null
+    );
     const adapter = useMemo(
         () => adaptersWithMobileWalletAdapter.find((a) => a.name === walletName) ?? null,
         [adaptersWithMobileWalletAdapter, walletName]

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -76,10 +76,7 @@ export function WalletProvider({
         }
         return [mobileWalletAdapter, ...adaptersWithStandardAdapters];
     }, [adaptersWithStandardAdapters, mobileWalletAdapter]);
-    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(
-        localStorageKey,
-        getIsMobile(adaptersWithStandardAdapters) ? SolanaMobileWalletAdapterWalletName : null
-    );
+    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(localStorageKey, null);
     const adapter = useMemo(
         () => adaptersWithMobileWalletAdapter.find((a) => a.name === walletName) ?? null,
         [adaptersWithMobileWalletAdapter, walletName]
@@ -105,8 +102,6 @@ export function WalletProvider({
         if (!adapter) return;
         function handleDisconnect() {
             if (isUnloadingRef.current) return;
-            // Leave the adapter selected in the event of a disconnection.
-            if (walletName === SolanaMobileWalletAdapterWalletName && getIsMobile(adaptersWithStandardAdapters)) return;
             setWalletName(null);
         }
         adapter.on('disconnect', handleDisconnect);
@@ -130,10 +125,6 @@ export function WalletProvider({
     }, [autoConnect, adapter]);
     const isUnloadingRef = useRef(false);
     useEffect(() => {
-        if (walletName === SolanaMobileWalletAdapterWalletName && getIsMobile(adaptersWithStandardAdapters)) {
-            isUnloadingRef.current = false;
-            return;
-        }
         function handleBeforeUnload() {
             isUnloadingRef.current = true;
         }
@@ -150,7 +141,7 @@ export function WalletProvider({
         };
     }, [adaptersWithStandardAdapters, walletName]);
     const handleConnectError = useCallback(() => {
-        if (adapter && adapter.name !== SolanaMobileWalletAdapterWalletName) {
+        if (adapter) {
             // If any error happens while connecting, unset the adapter.
             changeWallet(null);
         }

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -76,12 +76,7 @@ export function WalletProvider({
         }
         return [mobileWalletAdapter, ...adaptersWithStandardAdapters];
     }, [adaptersWithStandardAdapters, mobileWalletAdapter]);
-    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(
-        localStorageKey,
-        adaptersWithStandardAdapters.length === 0 && getIsMobile(adaptersWithStandardAdapters)
-            ? SolanaMobileWalletAdapterWalletName
-            : null
-    );
+    const [walletName, setWalletName] = useLocalStorage<WalletName | null>(localStorageKey, null);
     const adapter = useMemo(
         () => adaptersWithMobileWalletAdapter.find((a) => a.name === walletName) ?? null,
         [adaptersWithMobileWalletAdapter, walletName]
@@ -107,13 +102,6 @@ export function WalletProvider({
         if (!adapter) return;
         function handleDisconnect() {
             if (isUnloadingRef.current) return;
-            // Leave the adapter selected in the event of a disconnection.
-            if (
-                walletName === SolanaMobileWalletAdapterWalletName &&
-                adaptersWithStandardAdapters.length === 0 &&
-                getIsMobile(adaptersWithStandardAdapters)
-            )
-                return;
             setWalletName(null);
         }
         adapter.on('disconnect', handleDisconnect);
@@ -157,14 +145,11 @@ export function WalletProvider({
         };
     }, [adaptersWithStandardAdapters, walletName]);
     const handleConnectError = useCallback(() => {
-        if (
-            adapter &&
-            (adapter.name !== SolanaMobileWalletAdapterWalletName || adaptersWithStandardAdapters.length !== 0)
-        ) {
+        if (adapter) {
             // If any error happens while connecting, unset the adapter.
             changeWallet(null);
         }
-    }, [adapter, changeWallet, adaptersWithStandardAdapters]);
+    }, [adapter, changeWallet]);
     const selectWallet = useCallback(
         (walletName: WalletName | null) => {
             hasUserSelectedAWallet.current = true;

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -125,6 +125,10 @@ export function WalletProvider({
     }, [autoConnect, adapter]);
     const isUnloadingRef = useRef(false);
     useEffect(() => {
+        if (walletName === SolanaMobileWalletAdapterWalletName && getIsMobile(adaptersWithStandardAdapters)) {
+            isUnloadingRef.current = false;
+            return;
+        }
         function handleBeforeUnload() {
             isUnloadingRef.current = true;
         }

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -89,14 +89,7 @@ export function WalletProvider({
     const changeWallet = useCallback(
         (nextWalletName: WalletName<string> | null) => {
             if (walletName === nextWalletName) return;
-            if (
-                adapter &&
-                // Selecting a wallet other than the mobile wallet adapter is not
-                // sufficient reason to call `disconnect` on the mobile wallet adapter.
-                // Calling `disconnect` on the mobile wallet adapter causes the entire
-                // authorization store to be wiped.
-                adapter.name !== SolanaMobileWalletAdapterWalletName
-            ) {
+            if (adapter) {
                 adapter.disconnect();
             }
             setWalletName(nextWalletName);

--- a/packages/core/react/src/WalletProvider.tsx
+++ b/packages/core/react/src/WalletProvider.tsx
@@ -78,8 +78,12 @@ export function WalletProvider({
     }, [adaptersWithStandardAdapters, mobileWalletAdapter]);
     const [walletName, setWalletName] = useLocalStorage<WalletName | null>(localStorageKey, null);
     const adapter = useMemo(
-        () => adaptersWithMobileWalletAdapter.find((a) => a.name === walletName) ?? null,
-        [adaptersWithMobileWalletAdapter, walletName]
+        () =>
+            adaptersWithMobileWalletAdapter.find((a) => a.name === walletName) ??
+            (adaptersWithMobileWalletAdapter.length === 1 && adaptersWithMobileWalletAdapter[0] === mobileWalletAdapter
+                ? mobileWalletAdapter
+                : null),
+        [adaptersWithMobileWalletAdapter, walletName, mobileWalletAdapter]
     );
     const changeWallet = useCallback(
         (nextWalletName: WalletName<string> | null) => {


### PR DESCRIPTION
Currently, if other wallets are available on a dApp on Android, the only one that can be used is the MWA. This PR updates the `WalletProvider` so that it won't be auto-selected and can be disconnected if other wallets are available.

Comments posted at https://github.com/alex-fung/wallet-adapter/pull/1 are already addressed (opened against wrong branch)

**Before:**
https://github.com/anza-xyz/wallet-adapter/assets/2409008/19a522f9-d8f1-4ad9-8374-03ac8ca35de8

**After:**
With MWA and another wallet:
https://github.com/anza-xyz/wallet-adapter/assets/2409008/36dca9c4-b585-4017-a84a-0fadeb8c10eb
With just MWA:
https://github.com/anza-xyz/wallet-adapter/assets/2409008/da684467-2791-428d-8783-3a9c5485542c



