### PR TITLE
Fix: BaseWalletConnection doesn't pass thru classname prop

### DIFF
--- a/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
+++ b/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
@@ -1,18 +1,19 @@
 import type { WalletName } from '@solana/wallet-adapter-base';
 import React from 'react';
+import type { ButtonProps } from './Button.js';
 import { Button } from './Button.js';
 import { WalletIcon } from './WalletIcon.js';
 
-type Props = React.ComponentProps<typeof Button> & {
+type Props = ButtonProps & {
     walletIcon?: string;
     walletName?: WalletName;
 };
 
-export function BaseWalletConnectionButton({ walletIcon, walletName, ...props }: Props) {
+export function BaseWalletConnectionButton({ walletIcon, walletName, className, ...props }: Props) {
     return (
         <Button
             {...props}
-            className="wallet-adapter-button-trigger"
+            className={'wallet-adapter-button-trigger ' + (className ?? '')}
             startIcon={
                 walletIcon && walletName ? (
                     <WalletIcon wallet={{ adapter: { icon: walletIcon, name: walletName } }} />


### PR DESCRIPTION
The BaseWalletConnection component is currently overwriting any className prop. I made it not do this. If this is intentional, then className should not be among its props.