### PR TITLE
Adds labels as a prop to WalletConnectButton.

### DIFF
--- a/packages/ui/react-ui/src/BaseWalletConnectButton.tsx
+++ b/packages/ui/react-ui/src/BaseWalletConnectButton.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BaseWalletConnectionButton } from './BaseWalletConnectionButton.js';
 import type { ButtonProps } from './Button.js';
 
-type Props = ButtonProps & {
+export type Props = ButtonProps & {
     labels: { [TButtonState in ReturnType<typeof useWalletConnectButton>['buttonState']]: string };
 };
 

--- a/packages/ui/react-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/react-ui/src/WalletConnectButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BaseWalletConnectButton, Props as BaseProps } from './BaseWalletConnectButton.js';
 
-export type Props = Omit<BaseProps, 'labels'> & {labels?: Partial<BaseProps['labels']>};
+export type WalletConnectButtonProps = Omit<BaseProps, 'labels'> & {labels?: Partial<BaseProps['labels']>};
 
 const LABELS = {
     connecting: 'Connecting ...',
@@ -10,7 +10,7 @@ const LABELS = {
     'no-wallet': 'Connect Wallet',
 } as const;
 
-export function WalletConnectButton(props: Props) {
+export function WalletConnectButton(props: WalletConnectButtonProps) {
     props.labels = { ...LABELS, ...props.labels };
     return <BaseWalletConnectButton {...(props as BaseProps)} />;
 }

--- a/packages/ui/react-ui/src/WalletConnectButton.tsx
+++ b/packages/ui/react-ui/src/WalletConnectButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { BaseWalletConnectButton } from './BaseWalletConnectButton.js';
-import type { ButtonProps } from './Button.js';
+import { BaseWalletConnectButton, Props as BaseProps } from './BaseWalletConnectButton.js';
+
+export type Props = Omit<BaseProps, 'labels'> & {labels?: Partial<BaseProps['labels']>};
 
 const LABELS = {
     connecting: 'Connecting ...',
@@ -9,6 +10,7 @@ const LABELS = {
     'no-wallet': 'Connect Wallet',
 } as const;
 
-export function WalletConnectButton(props: ButtonProps) {
-    return <BaseWalletConnectButton {...props} labels={LABELS} />;
+export function WalletConnectButton(props: Props) {
+    props.labels = { ...LABELS, ...props.labels };
+    return <BaseWalletConnectButton {...(props as BaseProps)} />;
 }


### PR DESCRIPTION
- Allows for i18n.
- Allows for customization.
- Both the labels object and the property are optional.
- Dependency inversion is good practice.
- It didn't make sense for labels to be a constant when they're the API one level below expects it as a prop.