### PR TITLE
Refactor default Mobile Wallet Adapter button UI

### DIFF
--- a/packages/ui/react-ui/styles.css
+++ b/packages/ui/react-ui/styles.css
@@ -218,6 +218,28 @@
     color: #fff;
 }
 
+.wallet-adapter-modal-header {
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 16px;
+    margin: 0;
+    padding: 0px 24px 8px 24px;
+    text-align: left;
+    align-self: flex-start;
+    color: #fff;
+}
+
+.mobile-wallet-adapter-button {
+    background-color: #512da8;
+    font-weight: 400;
+    max-width: 85%;
+    border-radius: 16px;
+    margin: 12px 12px 36px 12px;
+    font-size: 18px;
+    justify-content: center;
+}
+
+
 @media (max-width: 374px) {
     .wallet-adapter-modal-title {
         font-size: 18px;


### PR DESCRIPTION
## Refactor MWA option in Modal UI

This PR proposes refactoring how the Mobile Wallet Adapter option is presented in the default `WalletModal` UI. Very open and looking forward to feedback and discussion.

## Rationale

The MWA option is an important action on mobile, one which maximizes wallet choice, since it will allow selection of any user-installed wallets which support the agnostic MWA protocol. 

This change aims to provide better context clues to the user around its usage. It replaces the current icon and text “Mobile wallet adapter”, which is not self-explanatory for users not familiar with what that means. The new wording is more descriptive and helps users understand the connection with the installed wallet apps on their phone.

## Changes

In `WalletModal`, detect the `mobileWalletAdapter` and, if present, render:
   - `On your phone:` header
   - `Use an installed wallet` button below header
   - If other wallets are present, render a `Other wallets:` header
   
## Next
If needed, we can additionally create a similar change in the UI for `ant-design` and `material-ui`.

## Testing

Tested on a local build with the example app across these different test cases, making sure to test that non-MWA modal's are unaffected.


| Test Case                     | Platform | Screenshot                                                                                   | Video                                                                                              |
|-------------------------------|-----------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
| 2 Listed Wallets, 0 Collapsed Wallets | Android   | <img width="250" alt="Screenshot 2024-07-25 at 2 39 15 PM" src="https://github.com/user-attachments/assets/b0218eac-cd6d-4f31-a835-ce8edf9f5503"> | [Video](https://github.com/user-attachments/assets/b52d72ec-617c-47c0-a0d5-3346a4bd5377)           |
| 2 Listed Wallets, 0 Collapsed Wallets  | Android        | <img width="250" alt="Screenshot 2024-07-25 at 2 58 23 PM" src="https://github.com/user-attachments/assets/4e355f41-cb56-4516-bb82-0f97fe8424a8">  | [Video](https://github.com/user-attachments/assets/3fca0fc2-dde4-4a5c-9add-4738441ce004)           |
|  1 Listed Wallets, 0 Collapsed Wallets                       | iOS         | <img width="250" alt="Screenshot 2024-07-25 at 2 56 16 PM" src="https://github.com/user-attachments/assets/21655392-1580-410c-a857-fb81a5a404b0">                                                                       | [Video](https://github.com/user-attachments/assets/30721f75-43da-40f1-bf91-366bd19f65c2)           |
|  2 Listed Wallets, 1 Collapsed Wallets                      | iOS              | <img width="250" alt="Screenshot 2024-07-25 at 2 43 49 PM" src="https://github.com/user-attachments/assets/9d68c1bb-424f-43de-bb16-6717b4f5854c"> | [Video](https://github.com/user-attachments/assets/9f1e0620-104e-4039-a8fe-85e5d7129206)           |
