### PR TITLE
Add iframe wallet adapter

### DIFF
--- a/packages/starter/example/src/components/ContextProvider.tsx
+++ b/packages/starter/example/src/components/ContextProvider.tsx
@@ -6,7 +6,7 @@ import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { WalletDialogProvider as MaterialUIWalletDialogProvider } from '@solana/wallet-adapter-material-ui';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider as ReactUIWalletModalProvider } from '@solana/wallet-adapter-react-ui';
-import { UnsafeBurnerWalletAdapter, IframeWalletAdapter } from '@solana/wallet-adapter-wallets';
+import { UnsafeBurnerWalletAdapter } from '@solana/wallet-adapter-wallets';
 import { type SolanaSignInInput } from '@solana/wallet-standard-features';
 import { verifySignIn } from '@solana/wallet-standard-util';
 import { clusterApiUrl } from '@solana/web3.js';

--- a/packages/starter/example/src/components/ContextProvider.tsx
+++ b/packages/starter/example/src/components/ContextProvider.tsx
@@ -6,7 +6,7 @@ import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
 import { WalletDialogProvider as MaterialUIWalletDialogProvider } from '@solana/wallet-adapter-material-ui';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletModalProvider as ReactUIWalletModalProvider } from '@solana/wallet-adapter-react-ui';
-import { UnsafeBurnerWalletAdapter } from '@solana/wallet-adapter-wallets';
+import { UnsafeBurnerWalletAdapter, IframeWalletAdapter } from '@solana/wallet-adapter-wallets';
 import { type SolanaSignInInput } from '@solana/wallet-standard-features';
 import { verifySignIn } from '@solana/wallet-standard-util';
 import { clusterApiUrl } from '@solana/web3.js';

--- a/packages/wallets/iframe/CHANGELOG.md
+++ b/packages/wallets/iframe/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @solana/wallet-adapter-iframe
+
+## 0.1.0
+
+- Initial version of @solana/wallet-adapter-iframe

--- a/packages/wallets/iframe/LICENSE
+++ b/packages/wallets/iframe/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/wallets/iframe/README.md
+++ b/packages/wallets/iframe/README.md
@@ -1,0 +1,8 @@
+# `@solana/wallet-adapter-iframe`
+
+Solana wallet adapter for iframe
+
+## Scenario
+
+In the case of dapp nested in an iframe, this adapter can be used to access the parent web wallet within the iframe
+without being restricted by browser security policies.

--- a/packages/wallets/iframe/package.json
+++ b/packages/wallets/iframe/package.json
@@ -1,0 +1,44 @@
+{
+    "name": "@solana/wallet-adapter-iframe",
+    "version": "0.1.0",
+    "author": "Solana Maintainers <maintainers@solana.foundation>",
+    "repository": "https://github.com/anza-xyz/wallet-adapter",
+    "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "lib",
+        "src",
+        "LICENSE"
+    ],
+    "engines": {
+        "node": ">=18"
+    },
+    "type": "module",
+    "sideEffects": false,
+    "main": "./lib/cjs/index.js",
+    "module": "./lib/esm/index.js",
+    "types": "./lib/types/index.d.ts",
+    "exports": {
+        "require": "./lib/cjs/index.js",
+        "import": "./lib/esm/index.js",
+        "types": "./lib/types/index.d.ts"
+    },
+    "scripts": {
+        "build": "tsc --build --verbose && pnpm run package",
+        "clean": "shx mkdir -p lib && shx rm -rf lib",
+        "lint": "prettier --check 'src/{*,**/*}.{ts,tsx,js,jsx,json}' && eslint",
+        "package": "shx mkdir -p lib/cjs && shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json"
+    },
+    "peerDependencies": {
+        "@solana/web3.js": "^1.77.3"
+    },
+    "dependencies": {
+        "@solana/wallet-adapter-base": "workspace:^"
+    },
+    "devDependencies": {
+        "@solana/web3.js": "^1.77.3",
+        "shx": "^0.3.4"
+    }
+}

--- a/packages/wallets/iframe/src/adapter.ts
+++ b/packages/wallets/iframe/src/adapter.ts
@@ -1,0 +1,189 @@
+import type { WalletName } from '@solana/wallet-adapter-base';
+import {
+    BaseMessageSignerWalletAdapter,
+    scopePollingDetectionStrategy,
+    WalletConnectionError,
+    WalletDisconnectionError,
+    WalletNotConnectedError,
+    WalletReadyState,
+    WalletSignMessageError,
+    WalletSignTransactionError,
+} from '@solana/wallet-adapter-base';
+import type { TransactionVersion, VersionedTransaction } from '@solana/web3.js';
+import { PublicKey, Transaction } from '@solana/web3.js';
+
+export const IframeWalletName = 'Iframe Wallet' as WalletName<'Iframe Wallet'>;
+
+type MessageType = 'install' | 'connect' | 'disconnect' | 'signMessage' | 'signTransaction';
+const MESSAGE_TARGET = 'iframe-wallet-adapter';
+
+interface WalletMessage {
+    target: string;
+    id: string;
+    type: MessageType;
+    payload?: any;
+}
+
+export class IframeWalletAdapter extends BaseMessageSignerWalletAdapter {
+    name = IframeWalletName;
+    icon =
+        'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzQiIGhlaWdodD0iMzAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0zNCAxMC42djIuN2wtOS41IDE2LjVoLTQuNmw2LTEwLjVhMi4xIDIuMSAwIDEgMCAyLTMuNGw0LjgtOC4zYTQgNCAwIDAgMSAxLjMgM1ptLTQuMyAxOS4xaC0uNmw0LjktOC40djQuMmMwIDIuMy0yIDQuMy00LjMgNC4zWm0yLTI4LjRjLS4zLS44LTEtMS4zLTItMS4zaC0xLjlsLTIuNCA0LjNIMzBsMS43LTNabS0zIDVoLTQuNkwxMC42IDI5LjhoNC43TDI4LjggNi40Wk0xOC43IDBoNC42bC0yLjUgNC4zaC00LjZMMTguNiAwWk0xNSA2LjRoNC42TDYgMjkuOEg0LjJjLS44IDAtMS43LS4zLTIuNC0uOEwxNSA2LjRaTTE0IDBIOS40TDcgNC4zaDQuNkwxNCAwWm0tMy42IDYuNEg1LjdMMCAxNi4ydjhMMTAuMyA2LjRaTTQuMyAwaC40TDAgOC4ydi00QzAgMiAxLjkgMCA0LjMgMFoiIGZpbGw9IiM5OTQ1RkYiLz48L3N2Zz4=';
+    url = 'https://github.com/anza-xyz/wallet-adapter';
+    supportedTransactionVersions: ReadonlySet<TransactionVersion> = new Set(['legacy', 0]);
+
+    private _connecting: boolean;
+    private _publicKey: PublicKey | null;
+    private _readyState: WalletReadyState =
+        typeof window === 'undefined' || typeof document === 'undefined' || window.parent === window
+            ? WalletReadyState.Unsupported
+            : WalletReadyState.NotDetected;
+    private _messageHandlers: Map<string, (response: any) => void>;
+
+    constructor(name?: string, icon?: string, url?: string) {
+        super();
+        if (name) {
+            this.name = name as WalletName<'Iframe Wallet'>;
+        }
+        if (icon) {
+            this.icon = icon;
+        }
+        if (url) {
+            this.url = url;
+        }
+        this._connecting = false;
+        this._publicKey = null;
+        this._messageHandlers = new Map();
+        if (this._readyState !== WalletReadyState.Unsupported) {
+            window.addEventListener('message', this._handleMessage);
+            scopePollingDetectionStrategy(() => {
+                if (this._readyState === WalletReadyState.Installed) {
+                    return true;
+                }
+                this._sendMessage('install')
+                    .then(() => {
+                        this._readyState = WalletReadyState.Installed;
+                        this.emit('readyStateChange', this._readyState);
+                    })
+                    .catch(() => {
+                        // skip
+                    });
+                return false;
+            });
+        }
+    }
+
+    get publicKey() {
+        return this._publicKey;
+    }
+
+    get connecting() {
+        return this._connecting;
+    }
+
+    get readyState() {
+        return this._readyState;
+    }
+
+    async connect(): Promise<void> {
+        try {
+            if (this.connected || this.connecting) {
+                return;
+            }
+            this._connecting = true;
+            const response = await this._sendMessage('connect');
+            if (response.error) {
+                throw new WalletConnectionError(response.error);
+            }
+            this._publicKey = new PublicKey(response.publicKey);
+            this.emit('connect', this._publicKey);
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        } finally {
+            this._connecting = false;
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        const wasConnected = this.connected;
+        this._publicKey = null;
+        try {
+            await this._sendMessage('disconnect');
+        } catch (error: any) {
+            this.emit('error', new WalletDisconnectionError(error?.message, error));
+        }
+        if (wasConnected) {
+            this.emit('disconnect');
+        }
+    }
+
+    async signMessage(message: Uint8Array): Promise<Uint8Array> {
+        try {
+            if (!this.connected) {
+                throw new WalletNotConnectedError();
+            }
+
+            const response = await this._sendMessage('signMessage', {
+                message: Array.from(message),
+            });
+
+            if (response.error) {
+                throw new WalletSignMessageError(response.error);
+            }
+
+            return new Uint8Array(response.signature);
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+
+    async signTransaction<T extends Transaction | VersionedTransaction>(transaction: T): Promise<T> {
+        try {
+            if (!this.connected) {
+                throw new WalletNotConnectedError();
+            }
+
+            const response = await this._sendMessage('signTransaction', {
+                transaction: Array.from(transaction.serialize({ verifySignatures: false })),
+            });
+
+            if (response.error) {
+                throw new WalletSignTransactionError(response.error);
+            }
+
+            return Transaction.from(response.signedTransaction) as T;
+        } catch (error: any) {
+            this.emit('error', error);
+            throw error;
+        }
+    }
+
+    private _handleMessage = (event: MessageEvent) => {
+        const message = event.data as WalletMessage;
+        if (message.target !== MESSAGE_TARGET) {
+            return;
+        }
+
+        const handler = this._messageHandlers.get(message.id);
+        if (handler) {
+            handler(message.payload);
+            this._messageHandlers.delete(message.id);
+        }
+    };
+
+    private async _sendMessage(type: MessageType, payload?: any): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const id = Math.random().toString(36).substring(8);
+            const message: WalletMessage = { target: MESSAGE_TARGET, type, payload, id };
+
+            this._messageHandlers.set(id, resolve);
+            window.parent.postMessage(message, '*');
+
+            setTimeout(() => {
+                this._messageHandlers.delete(id);
+                reject(new Error('Request timeout'));
+            }, 10_000);
+        });
+    }
+}

--- a/packages/wallets/iframe/src/index.ts
+++ b/packages/wallets/iframe/src/index.ts
@@ -1,0 +1,1 @@
+export * from './adapter.js';

--- a/packages/wallets/iframe/tsconfig.cjs.json
+++ b/packages/wallets/iframe/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../../tsconfig.cjs.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/cjs"
+    }
+}

--- a/packages/wallets/iframe/tsconfig.esm.json
+++ b/packages/wallets/iframe/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../../tsconfig.esm.json",
+    "include": ["src"],
+    "compilerOptions": {
+        "outDir": "lib/esm",
+        "declarationDir": "lib/types"
+    }
+}

--- a/packages/wallets/iframe/tsconfig.json
+++ b/packages/wallets/iframe/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../../tsconfig.root.json",
+    "references": [
+        {
+            "path": "./tsconfig.cjs.json"
+        },
+        {
+            "path": "./tsconfig.esm.json"
+        }
+    ]
+}

--- a/packages/wallets/wallets/package.json
+++ b/packages/wallets/wallets/package.json
@@ -70,7 +70,8 @@
         "@solana/wallet-adapter-trust": "workspace:^",
         "@solana/wallet-adapter-unsafe-burner": "workspace:^",
         "@solana/wallet-adapter-walletconnect": "workspace:^",
-        "@solana/wallet-adapter-xdefi": "workspace:^"
+        "@solana/wallet-adapter-xdefi": "workspace:^",
+        "@solana/wallet-adapter-iframe": "workspace:^"
     },
     "devDependencies": {
         "@solana/web3.js": "^1.77.3",

--- a/packages/wallets/wallets/src/index.ts
+++ b/packages/wallets/wallets/src/index.ts
@@ -32,5 +32,6 @@ export * from '@solana/wallet-adapter-torus';
 export * from '@solana/wallet-adapter-trezor';
 export * from '@solana/wallet-adapter-trust';
 export * from '@solana/wallet-adapter-unsafe-burner';
+export * from '@solana/wallet-adapter-iframe';
 export * from '@solana/wallet-adapter-walletconnect';
 export * from '@solana/wallet-adapter-xdefi';

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -144,6 +144,9 @@
         },
         {
             "path": "./packages/wallets/xdefi/tsconfig.json"
+        },
+        {
+            "path": "./packages/wallets/iframe/tsconfig.json"
         }
     ]
 }


### PR DESCRIPTION
Add wallet adapter for iframe

In the case of dapp nested in an iframe, this adapter can be used to access the parent web wallet within the iframe
without being restricted by browser security policies.
