### PR TITLE
docs: fix and simplify button handler example

### DIFF
--- a/packages/core/react/README.md
+++ b/packages/core/react/README.md
@@ -60,17 +60,20 @@ function CustomConnectButton() {
     const handleClick = useCallback(() => {
         switch (buttonState) {
             case 'connected':
-                return onDisconnect;
+                onDisconnect();
+                break;
             case 'connecting':
             case 'disconnecting':
                 break;
             case 'has-wallet':
-                return onConnect;
+                onConnect();
+                break;
             case 'no-wallet':
-                return onSelectWallet;
+                onSelectWallet();
                 break;
         }
     }, [buttonState, onDisconnect, onConnect, onSelectWallet]);
+
     return (
         <>
             <button disabled={buttonState === 'connecting' || buttonState === 'disconnecting'} onClick={handleClick}>

--- a/packages/core/react/README.md
+++ b/packages/core/react/README.md
@@ -60,16 +60,16 @@ function CustomConnectButton() {
     const handleClick = useCallback(() => {
         switch (buttonState) {
             case 'connected':
-                onDisconnect();
+                onDisconnect?.();
                 break;
             case 'connecting':
             case 'disconnecting':
                 break;
             case 'has-wallet':
-                onConnect();
+                onConnect?.();
                 break;
             case 'no-wallet':
-                onSelectWallet();
+                onSelectWallet?.();
                 break;
         }
     }, [buttonState, onDisconnect, onConnect, onSelectWallet]);

--- a/packages/core/react/README.md
+++ b/packages/core/react/README.md
@@ -57,26 +57,27 @@ function CustomConnectButton() {
             label = 'Select Wallet';
             break;
     }
-    const handleClick = useCallback(() => {
-        switch (buttonState) {
-            case 'connected':
-                onDisconnect?.();
-                break;
-            case 'connecting':
-            case 'disconnecting':
-                break;
-            case 'has-wallet':
-                onConnect?.();
-                break;
-            case 'no-wallet':
-                onSelectWallet?.();
-                break;
-        }
-    }, [buttonState, onDisconnect, onConnect, onSelectWallet]);
-
     return (
         <>
-            <button disabled={buttonState === 'connecting' || buttonState === 'disconnecting'} onClick={handleClick}>
+            <button
+                disabled={buttonState === 'connecting' || buttonState === 'disconnecting'}
+                onClick={() => {
+                    switch (buttonState) {
+                        case 'connected':
+                            onDisconnect?.();
+                            break;
+                        case 'connecting':
+                        case 'disconnecting':
+                            break;
+                        case 'has-wallet':
+                            onConnect?.();
+                            break;
+                        case 'no-wallet':
+                            onSelectWallet?.();
+                            break;
+                    }
+                }}
+            >
                 {label}
             </button>
             {walletModalConfig ? (


### PR DESCRIPTION
## Summary
Fix incorrect event handler in README and improve code clarity

## Problem
The example code from the README didn't work when implemented - the `handleClick` was returning functions instead of executing them. 

## Solution
This PR makes the handler execute functions directly for a more straightforward implementation. Since handler functions from `useWalletMultiButton` can be `undefined`, the code uses optional chaining for concise null checks. The higher-order function pattern was removed to prioritize readability in the example.