### PR TITLE
Update LedgerAdapter to latest Solana Ledger App (to enable message signing)

### DIFF
--- a/packages/wallets/ledger/src/adapter.ts
+++ b/packages/wallets/ledger/src/adapter.ts
@@ -151,7 +151,10 @@ export class LedgerWalletAdapter extends BaseSignerWalletAdapter {
                 if (!transport || !publicKey) throw new WalletNotConnectedError();
 
                 const appConfig = await getAppConfiguration(transport);
-                if (appConfig.version < '1.8.0') throw new WalletSignMessageError('Signing off-chain messages requires Solana Ledger App 1.8.0 or later');
+                const [major, minor] = appConfig.version.split('.').map(Number);
+                if (major < 1 || (major === 1 && minor < 8)) {
+                    throw new WalletSignMessageError('Signing off-chain messages requires Solana Ledger App 1.8.0 or later');
+                }
 
                 const offchainMessage = new OffchainMessage({ message: Buffer.from(message.buffer), signerAddress: publicKey });
                 if (!offchainMessage.isLedgerSupported(appConfig.blindSigningEnabled)) throw new WalletSignMessageError('Ledger does not support signing this message. Either the message body is not printable ASCII and blind signing needs to be enabled, or the message is too long to be signed on Ledger.');


### PR DESCRIPTION
### PR Description

This PR updates the existing `ledger-adapter-example` branch to work with the latest Solana Ledger App release, which finally complies with [Anza's off-chain message signing (OCMS)](https://docs.anza.xyz/proposals/off-chain-message-signing) spec.

**Quick Motivation:** 
At Sovereign Labs, we’re supporting teams building Solana Network Extensions (such as [Bullet](https://www.bullet.xyz/) and [Termina](https://www.termina.technology/)), and having an off-chain message signing flow will greatly improve the UX for these applications. We’re hoping that major wallets like Phantom and Solflare can integrate Ledger’s off-chain message signing flow ASAP, hence I’m making this PR to get the ball rolling.

### Highlights:
- **Message signing for Solana Ledger App versions below 1.8.0 is disabled.** According to my local testing, early versions of the Solana Ledger App allowed signing plain messages (Phantom does as well), but this capability was disabled in recent versions. Around version 1.7.0, the Solana Ledger App started requiring these messages to follow the OffchainMessage spec, but there were a few issues. The 1.8.0 app finally correctly adheres to Anza’s OffchainMessage spec (it now includes elements such as the Application domain, which was missing previously). To avoid confusion for users and wallet providers, it seems sensible to disable Ledger message signing for app versions below 1.8.0, but I’m open to feedback on this.
- **If you test the Ledger “sign message” flow with the example application, it will fail.** This is because the example message-signing app (you can find it at `packages/starter/example/src/components/SignMessage.tsx`) verifies the plain message provided by the user. However, the [Anza spec](https://docs.anza.xyz/proposals/off-chain-message-signing#signing) explicitly states that signing and verification must occur on the result of appending the message body to the message preamble. Thus, the correct verification method would be to construct an `OffChainMessage` instance from the message body and then verify against the serialized version of this instance. I did not included this change here to keep the diff minimal, and also because this breaks Phantom (which mistakenly identifies a serialized `OffChainMessage` as a transaction and prevents the user from signing it). The serialized `OffChainMessage` instances begin with 0xff, which I believe is explicitly disallowed as a transaction by the runtime, so ideally, the Phantom team should remove this check.
- It appears the Anza spec assumes the maximum length a hardware wallet supports is 1232 bytes. The latest Solana Ledger App actually supports up to 15312 bytes. However, to align with the Anza spec, I’ve kept the OFFCM_MAX_LEDGER_LEN at 1212. I don’t have strong opinions about this—my main goal is just to see this standard widely adopted ASAP.
- Lastly, we currently create an `OffChainMessage` instance only in the Ledger integration. However, any off-chain message should normally follow the same format. As a result, Phantom and other wallets should ideally also use the `OffChainMessage` instance to construct a correctly formatted message before prompting the user to sign, even if they're not using a hardware wallet. But again, to keep the diff minimal (and due to this Phantom's current instance not accepting OffchainMessage as a valid message), I'm constructing the `OffChainMessage` instance in `LedgerWalletAdapter` and not in the shared `SignMessage` component (`packages/starter/example/src/components/SignMessage.tsx`).