### PR TITLE
Fixed cannot add custom class names to WalletMultiButton  component.

### DIFF
--- a/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
+++ b/packages/ui/react-ui/src/BaseWalletConnectionButton.tsx
@@ -11,8 +11,8 @@ type Props = React.ComponentProps<typeof Button> & {
 export function BaseWalletConnectionButton({ walletIcon, walletName, ...props }: Props) {
     return (
         <Button
-            {...props}
             className="wallet-adapter-button-trigger"
+            {...props}
             startIcon={
                 walletIcon && walletName ? (
                     <WalletIcon wallet={{ adapter: { icon: walletIcon, name: walletName } }} />


### PR DESCRIPTION
The `WalletMultiButton` component allows a className prop. But `BaseWalletConnectionButton` overrides className using `className="wallet-adapter-button-trigger"` which is preventing from overriding default styles.

The suggested change allows to override the default CSS class name which allows custom styling for the button:

```tsx
function Test() {
  return (
    <WalletMultiButton
      className='button button--something'
    />
  );
}
```

An example applying Tailwind classes for a button using CVA:

```tsx
function Test() {
  return (
    <WalletMultiButton
      className={buttonVariants({
        size: 'lg',
      })}
    />
  );
}
```