### PR TITLE
docs(example): added note about wallet adapter behavior in App.tsx

### DIFF
--- a/packages/starter/react-ui-starter/src/App.tsx
+++ b/packages/starter/react-ui-starter/src/App.tsx
@@ -43,6 +43,13 @@ const Context: FC<{ children: ReactNode }> = ({ children }) => {
 
     return (
         <ConnectionProvider endpoint={endpoint}>
+            
+            /*  
+              Avoid adding specific wallet adapters (e.g. PhantomWalletAdapter) to the `wallets` array.
+              Forcing adapters into the list can cause unexpected UI behavior—such as wallet button getting stuck on 
+              redirecting users to the wallet’s website and preventing proper disconnect particularly when the wallet extension is not installed.
+            */
+            
             <WalletProvider wallets={wallets} autoConnect>
                 <WalletModalProvider>{children}</WalletModalProvider>
             </WalletProvider>


### PR DESCRIPTION
This change adds a note to the wallet adapter example describing behavior that can occur when specific wallet adapters are manually added to the wallets array.

Explicitly adding adapters may cause wallets to appear even when they are not installed, which can lead to redirects to the wallet’s website or issues with disconnect behavior. Documenting this in the example helps prevent confusion for developers copying the code.