### PR TITLE
Fix LICENSE copyright placeholder text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021-2025 Solana Maintainers <maintainers@solana.foundation>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Replace the boilerplate placeholder text `[yyyy] [name of copyright owner]` with actual copyright information
- Start year: 2021 (first commit date from git history)
- End year: 2025 (current development year)
- Copyright holder: Solana Maintainers (consistent with package.json author field)

## Related Issue
Fixes #1114

## Test plan
- [x] Verify the copyright notice follows Apache 2.0 license appendix format
- [x] Verify the year range matches the project's git history (2021-present)
- [x] Verify the copyright holder matches the package.json author field