### PR TITLE
Update BUILD.md with correct version requirements

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,10 +2,10 @@
 
 ### 0. Prerequisites
 
-* Node 18+
-* PNPM 9+
+* Node 20+
+* PNPM 10.12.1
 
-If you have Node 16+, you can [activate PNPM with Corepack](https://pnpm.io/installation#using-corepack):
+If you have Node 20+, you can [activate PNPM with Corepack](https://pnpm.io/installation#using-corepack):
 ```shell
 corepack enable
 corepack prepare pnpm@`npm info pnpm --json | jq -r .version` --activate
@@ -13,7 +13,7 @@ corepack prepare pnpm@`npm info pnpm --json | jq -r .version` --activate
 
 Corepack requires a version to enable, so if you don't have [jq](https://stedolan.github.io/jq/) installed, you can [install it](https://formulae.brew.sh/formula/jq), or just manually get the current version of pnpm with `npm info pnpm` and use it like this:
 ```shell
-corepack prepare pnpm@9.1.0 --activate
+corepack prepare pnpm@10.12.1 --activate
 ```
 
 ### 1. Clone the project:


### PR DESCRIPTION
## Summary
- Update Node.js version requirement from 18+ to 20+ to match package.json
- Update PNPM version requirement from 9+ to 10.12.1 to match package.json
- Update the example corepack command to use the correct pnpm version (10.12.1)

The current BUILD.md documentation was outdated and did not match the actual requirements specified in package.json, which could confuse developers trying to build from source.

## Test plan
- [x] Version requirements match package.json engines field
- [x] Example corepack command uses correct pnpm version